### PR TITLE
Change npm --watch command so that it works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You can compile, watch add-on source files, and trigger recompilation on change:
 
 ```
 cd ~/.../your-new-local-addon  
-npm run build --watch
+npm run build -- --watch
 ```
 
 Or using **yarn**:


### PR DESCRIPTION
Tweak the documentation to work for `npm` with `--watch` flag.

The `npm` command does not have a `--watch` flag, but `tsc` (the `build` script) does. We need `npm` to pass that through to `tsc` and not try to interpret the flag itself. 