### PR TITLE
docs: mention install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,6 @@ The above steps should look something like this to install the repo in a `~/src`
 mkdir -p ~/src && cd ~/src
 git clone git@github.com:getflywheel/create-local-addon.git
 cd create-local-addon
-npm install -g
+npm install && npm install -g
 ```
 


### PR DESCRIPTION
Without `npm install`, running create-local-addon after `npm install -g` fails with a "Error: Cannot find module 'minimist'" error due to the globally installed version missing its deps.


```
> create-local-addon
node:internal/modules/cjs/loader:1080
  throw err;
  ^

Error: Cannot find module 'minimist'
Require stack:
- /Users/user.name/path/create-local-addon/index.js
```