### PR TITLE
Update homepage URL to point to help docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ So you want to create your own Local add-on? Look no further! This generator can
 Local is even better with add-ons! Add-ons can add extra functionality and convenience to your development workflow. There are some amazing add-ons already available for Local in the add-on marketplace –– but the best add-ons could be the ones you make yourself! This generator is designed to help you get started building your own add-on with little effort; it takes care of all the setup and lets you focus on making an amazing new add-on for the Local application.
 
 Once you are done, you can easily use your add-on within Local to enhance your workflow. If you want to go a step further, you can even submit your add-on to be added to the public Local add-on marketplace! 
-Learn more at [http://build.localwp.com](http://build.localwp.com/).
+Learn more at [https://localwp.com/help-docs/](https://localwp.com/help-docs/).
 
 ## What You'll Need Before Starting
 Here are a few things you'll want to make sure you have set up before using the Local Add-on Generator.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/getflywheel/create-local-addon"
   },
-  "homepage": "https://build.localwp.com",
+  "homepage": "https://localwp.com/help-docs/",
   "author": "Local Team <local-dev@getflywheel.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Updates the `homepage` field in package.json from `https://build.localwp.com` to `https://localwp.com/help-docs/` to reflect the current documentation location.